### PR TITLE
Fix phpstan Level 5-ish errors

### DIFF
--- a/classes/BlueChip/WooCommerce/Mpay24Gateway/Gateway.php
+++ b/classes/BlueChip/WooCommerce/Mpay24Gateway/Gateway.php
@@ -19,7 +19,7 @@ class Gateway extends \WC_Payment_Gateway
 
 
     /**
-     * @var \BlueChip\WooCommerce\MPay24Gateway\Mpay24
+     * @var \BlueChip\WooCommerce\Mpay24Gateway\Mpay24
      */
     private $mpay24;
 

--- a/classes/BlueChip/WooCommerce/Mpay24Gateway/IPN.php
+++ b/classes/BlueChip/WooCommerce/Mpay24Gateway/IPN.php
@@ -114,6 +114,7 @@ abstract class IPN
      */
     public static function processConfirmationRequest()
     {
+        /** @var array<string, mixed> */
         $request_data = wp_unslash($_GET);
 
         $status = $request_data['STATUS'] ?? '';
@@ -142,7 +143,7 @@ abstract class IPN
 
     /**
      * @param array $data Request data.
-     * @return null|WC_Order Order instance if confirmation request is valid, null otherwise.
+     * @return null|\WC_Order Order instance if confirmation request is valid, null otherwise.
      */
     protected static function validateConfirmationRequest(array $data): ?\WC_Order
     {
@@ -211,7 +212,7 @@ abstract class IPN
      * @link https://docs.mpay24.com/docs/transaction-states All transaction states
      * @link https://docs.mpay24.com/docs/payment-notification#section-notification-values Request data items
      *
-     * @param \WC_Order $order_id
+     * @param \WC_Order $order
      * @param string $status
      * @param string $tid
      * @param string $mpay_tid

--- a/classes/BlueChip/WooCommerce/Mpay24Gateway/IpTools.php
+++ b/classes/BlueChip/WooCommerce/Mpay24Gateway/IpTools.php
@@ -18,7 +18,7 @@ abstract class IpTools
         [$net, $mask] = explode('/', $subnet);
 
         $_net = ip2long($net);
-        $_mask = ~((1 << (32 - $mask)) - 1);
+        $_mask = ~((1 << (32 - intval($mask))) - 1);
 
         $_ip = ip2long($ip);
 


### PR DESCRIPTION
phpstan.neon.dist

```yaml
includes:
    - phar://phpstan.phar/conf/bleedingEdge.neon
    - vendor/szepeviktor/phpstan-wordpress/extension.neon
parameters:
    level: max
    inferPrivatePropertyTypeFromConstructor: true
    paths:
        - %currentWorkingDirectory%/bc-woocommerce-mpay24-gateway.php
        - %currentWorkingDirectory%/classes/
    autoload_files:
        # Define WC_LOG_DIR
        - %currentWorkingDirectory%/tests/bootstrap.php
        # WooCommerce
        - %currentWorkingDirectory%/tests/woocommerce-stubs-3.6.5.php
        - %currentWorkingDirectory%/bc-woocommerce-mpay24-gateway.php
    ignoreErrors:
        # Uses func_get_args()
        - '#^Function add_query_arg invoked with [123] parameters?, 0 required\.$#'
        # __get()
        - '#^Access to an undefined property Mpay24\\Mpay24Order::\$Order\.$#'
```
